### PR TITLE
Update mailchain installation doc

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -8,7 +8,7 @@ description: Follow the steps below to install Mailchain...
 
 To install Mailchain for the first time, we recommend using [Homebrew](https://brew.sh/) to download, install and manage the application on your local machine.
 
-First we need to tap into mailchain repository to the list of formulae that brew tracks using.
+First we need to tap mailchain repository to the list of formulae that brew tracks using
 
 ```bash
 brew tap mailchain/tap

--- a/installation.md
+++ b/installation.md
@@ -8,6 +8,13 @@ description: Follow the steps below to install Mailchain...
 
 To install Mailchain for the first time, we recommend using [Homebrew](https://brew.sh/) to download, install and manage the application on your local machine.
 
+First we need to tap into mailchain repository to the list of formulae that brew tracks using.
+
+```bash
+brew tap mailchain/tap
+```
+
+Once you have done this, you can install mailchain using 
 ```bash
 brew install mailchain
 ```


### PR DESCRIPTION
Updated Mailchain installation doc to tap Mailchain formulae to homebrew. 
This is a fix for
https://github.com/mailchain/mailchain/issues/330